### PR TITLE
Update .csv filename to be Windows-compatible

### DIFF
--- a/export_audit_trail.py
+++ b/export_audit_trail.py
@@ -15,7 +15,7 @@ API_KEY_ENV = "API_KEY"
 AUDIT_TRAIL_PATH = "api/audittrail/v1/auditevents"
 BATCH_LIMIT = 1000
 
-CSV_BASE_FILENAME=f"audit_trail_export_{datetime.now().strftime('%Y-%m-%d:%H-%M-%S')}.csv"
+CSV_BASE_FILENAME=f"audit_trail_export_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.csv"
 
 # HEADERS
 UTC_TIMESTAMP = "DATE & TIME (UTC)"


### PR DESCRIPTION
CSV_BASE_FILENAME variable includes a colon, which is an invalid character for Windows filenames. Updated to use an underscore instead so this can run on Windows-based systems.